### PR TITLE
Fix list BParser

### DIFF
--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -82,12 +82,11 @@ dict name = BParser $ \b -> case b of
                               BDict _ -> Error $ "Name not found in dictionary: " ++ name
                               _ -> Error $ "Not a dictionary: " ++ name
 
-list :: String -> BParser a -> BParser [a]
-list name p
-    = dict name >>= \lst ->
-      BParser $ \b -> case lst of
-                      BList bs -> foldr (cat . runB p) (Ok [] b) bs
-                      _ -> Error $ "Not a list: " ++ name
+list :: BParser a -> BParser [a]
+list p
+    = BParser $ \lst -> case lst of
+          BList (bs) -> foldr (cat . runB p) (Ok [] (BList [])) bs
+          _ -> Error $ "Not a list: " ++ (show lst)
     where cat (Ok v _) (Ok vs b) = Ok (v:vs) b
           cat (Ok _ _) (Error str) = Error str
           cat (Error str) _ = Error str

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -79,3 +79,20 @@ main = hspec $ do
         runParser (list $ list $ bbytestring token)
                   (BList [BList [BString "foo", BString "bar"], BList []])
         `shouldBe` Right [["foo", "bar"], []]
+    it "parses BDicts" $
+        runParser (bint $ dict "foo")
+                  (BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)])
+        `shouldBe` Right 1
+    it "parses BLists of BDicts" $
+        runParser (list $ dict "foo")
+                  (BList [
+                    BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)],
+                    BDict $ Map.singleton "foo" (BString "bam")
+                  ])
+        `shouldBe` Right [BInt 1, BString "bam"]
+    it "parses BDicts of BLists" $
+        runParser (dict "foo" >>= setInput >> list (bstring token))
+                  (BDict $ Map.singleton "foo" (BList [
+                    BString "foo", BString "bar"
+                  ]))
+        `shouldBe` Right ["foo", "bar"]

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,7 +1,6 @@
 
 {-# LANGUAGE OverloadedStrings #-}
 
-import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map as Map
 
 import Test.Hspec
@@ -16,11 +15,11 @@ main = hspec $ do
 
   describe "Data.BEncode encoding" $ do
     it "encodes" $ do
-        bRead (L.pack "i42e") `shouldBe` Just (BInt 42)
+        bRead "i42e" `shouldBe` Just (BInt 42)
     it "encodes" $ do
-        bRead (L.pack "3:foo") `shouldBe` Just (BString (L.pack "foo"))
+        bRead "3:foo" `shouldBe` Just (BString "foo")
     it "encodes" $ do
-        bRead (L.pack "5:café") `shouldBe` Just (BString (L.pack "café"))
+        bRead "5:café" `shouldBe` Just (BString "café")
     it "encodes" $ do
         bRead "l5:helloi42eli-1ei0ei1ei2ei3e4:fouree"
           `shouldBe` Just (BList [ BString "hello", BInt 42, bll ])

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -14,16 +14,15 @@ main = hspec $ do
   let bll = BList [BInt (-1), BInt 0, BInt 1, BInt 2, BInt 3, BString "four"]
 
   describe "Data.BEncode encoding" $ do
-    it "encodes" $ do
+    it "encodes integers" $ do
         bRead "i42e" `shouldBe` Just (BInt 42)
-    it "encodes" $ do
+    it "encodes strings" $ do
         bRead "3:foo" `shouldBe` Just (BString "foo")
-    it "encodes" $ do
+    it "encodes strings with special characters in Haskell source" $ do
         bRead "5:café" `shouldBe` Just (BString "café")
-    it "encodes" $ do
+    it "encodes lists" $ do
         bRead "l5:helloi42eli-1ei0ei1ei2ei3e4:fouree"
           `shouldBe` Just (BList [ BString "hello", BInt 42, bll ])
-
 
   describe "Data.BEncode decoding" $ do
     it "decodes int" $ do

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -23,6 +23,11 @@ main = hspec $ do
     it "encodes lists" $ do
         bRead "l5:helloi42eli-1ei0ei1ei2ei3e4:fouree"
           `shouldBe` Just (BList [ BString "hello", BInt 42, bll ])
+    it "encodes nested lists" $ do
+        bRead "ll5:helloi62eel3:fooee"
+          `shouldBe` Just (BList
+            [ BList [ BString "hello", BInt 62 ],
+              BList [ BString "foo" ] ])
 
   describe "Data.BEncode decoding" $ do
     it "decodes int" $ do

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -54,7 +54,7 @@ main = hspec $ do
         bRead "l5:helloi42eli-1ei0ei1ei2ei3e4:fouree"
             `shouldBe` Just (BList [ BString "hello", BInt 42, bll])
 
-  describe "Data.BEncode.Parser parsing" $ do
+  describe "Data.BEncode.Parser" $ do
     it "parses BInts" $ do
         runParser (bint token) (BInt 42) `shouldBe` Right 42
     it "parses BStrings" $ do

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -60,4 +60,22 @@ main = hspec $ do
         runParser (bstring token) (BString "foo") `shouldBe` Right "foo"
     it "parses BStrings with special characters in Haskell source" $
         runParser (bbytestring token) (BString "café") `shouldBe` Right "café"
-    -- it "encodes lists" $ undefined
+    it "parses empty BLists" $
+        runParser (list token) (BList []) `shouldBe` Right []
+    it "parses BLists of BInts and BStrings" $
+        runParser (list token) (BList [BInt 1, BString "foo"])
+        `shouldBe` Right [BInt 1, BString "foo"]
+    it "parses BLists of Integers" $
+        runParser (list $ bint token) (BList [BInt 1, BInt 2])
+        `shouldBe` Right [1, 2]
+    it "parses BLists of Strings" $
+        runParser (list $ bstring token) (BList [BString "foo", BString "bar"])
+        `shouldBe` Right ["foo", "bar"]
+    it "parses BLists of Strings into ByteStrings" $
+        runParser (list $ bbytestring token) 
+                  (BList [BString "foo", BString "bar"])
+        `shouldBe` Right ["foo", "bar"]
+    it "parses nested BLists" $
+        runParser (list $ list $ bbytestring token)
+                  (BList [BList [BString "foo", BString "bar"], BList []])
+        `shouldBe` Right [["foo", "bar"], []]

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -4,7 +4,7 @@ import qualified Data.Map as Map
 
 import Test.Hspec
 import Data.BEncode
-
+import Data.BEncode.Parser
 
 main :: IO ()
 main = hspec $ do
@@ -44,8 +44,8 @@ main = hspec $ do
         bPack (BList [ BList [BInt 1], BInt 1, BInt 2, BInt 3])
           `shouldBe` "lli1eei1ei2ei3ee"
     it "decodes hash" $ do
-        let dict = Map.fromList [("foo", BString "bar"), ("baz",BString "qux")]
-        bPack (BDict dict) `shouldBe` "d3:baz3:qux3:foo3:bare"
+        let d = Map.fromList [("foo", BString "bar"), ("baz",BString "qux")]
+        bPack (BDict d) `shouldBe` "d3:baz3:qux3:foo3:bare"
     -- FIX
     -- it "decodes unicode" $ do
     --   bPack (BString "café") `shouldBe` "5:café"
@@ -53,3 +53,12 @@ main = hspec $ do
     it "decodes lists of lists" $ do
         bRead "l5:helloi42eli-1ei0ei1ei2ei3e4:fouree"
             `shouldBe` Just (BList [ BString "hello", BInt 42, bll])
+
+  describe "Data.BEncode.Parser parsing" $ do
+    it "parses BInts" $ do
+        runParser (bint token) (BInt 42) `shouldBe` Right 42
+    it "parses BStrings" $ do
+        runParser (bstring token) (BString "foo") `shouldBe` Right "foo"
+    it "parses BStrings with special characters in Haskell source" $ do
+        runParser (bbytestring token) (BString "café") `shouldBe` Right "café"
+    -- it "encodes lists" $ undefined

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -9,38 +9,37 @@ import Data.BEncode.Parser
 main :: IO ()
 main = hspec $ do
 
-
   let bll = BList [BInt (-1), BInt 0, BInt 1, BInt 2, BInt 3, BString "four"]
 
   describe "Data.BEncode encoding" $ do
-    it "encodes integers" $ do
+    it "encodes integers" $
         bRead "i42e" `shouldBe` Just (BInt 42)
-    it "encodes strings" $ do
+    it "encodes strings" $
         bRead "3:foo" `shouldBe` Just (BString "foo")
-    it "encodes strings with special characters in Haskell source" $ do
+    it "encodes strings with special characters in Haskell source" $
         bRead "5:café" `shouldBe` Just (BString "café")
-    it "encodes lists" $ do
+    it "encodes lists" $
         bRead "l5:helloi42eli-1ei0ei1ei2ei3e4:fouree"
           `shouldBe` Just (BList [ BString "hello", BInt 42, bll ])
-    it "encodes nested lists" $ do
+    it "encodes nested lists" $
         bRead "ll5:helloi62eel3:fooee"
           `shouldBe` Just (BList
             [ BList [ BString "hello", BInt 62 ],
               BList [ BString "foo" ] ])
 
   describe "Data.BEncode decoding" $ do
-    it "decodes int" $ do
+    it "decodes int" $
         bPack (BInt 42) `shouldBe` "i42e"
-    it "decodes null int" $ do
+    it "decodes null int" $
         bPack (BInt 0) `shouldBe` "i0e"
-    it "decodes negative int" $ do
+    it "decodes negative int" $
         bPack (BInt (-42)) `shouldBe` "i-42e"
     it "decodes string" $ do
         bPack (BString "foo") `shouldBe` "3:foo"
         bPack (BString "") `shouldBe` "0:"
-    it "decodes lists" $ do
+    it "decodes lists" $
         bPack (BList [BInt 1, BInt 2, BInt 3]) `shouldBe` "li1ei2ei3ee"
-    it "decodes lists of lists" $ do
+    it "decodes lists of lists" $
         bPack (BList [ BList [BInt 1], BInt 1, BInt 2, BInt 3])
           `shouldBe` "lli1eei1ei2ei3ee"
     it "decodes hash" $ do
@@ -50,15 +49,15 @@ main = hspec $ do
     -- it "decodes unicode" $ do
     --   bPack (BString "café") `shouldBe` "5:café"
     --   bPack (BList [BString "你好", BString "中文"]) `shouldBe` "l6:你好6:中文e"
-    it "decodes lists of lists" $ do
+    it "decodes lists of lists" $
         bRead "l5:helloi42eli-1ei0ei1ei2ei3e4:fouree"
             `shouldBe` Just (BList [ BString "hello", BInt 42, bll])
 
   describe "Data.BEncode.Parser" $ do
-    it "parses BInts" $ do
+    it "parses BInts" $
         runParser (bint token) (BInt 42) `shouldBe` Right 42
-    it "parses BStrings" $ do
+    it "parses BStrings" $
         runParser (bstring token) (BString "foo") `shouldBe` Right "foo"
-    it "parses BStrings with special characters in Haskell source" $ do
+    it "parses BStrings with special characters in Haskell source" $
         runParser (bbytestring token) (BString "café") `shouldBe` Right "café"
     -- it "encodes lists" $ undefined

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -96,3 +96,20 @@ main = hspec $ do
                     BString "foo", BString "bar"
                   ]))
         `shouldBe` Right ["foo", "bar"]
+    it "parses optional BInts" $ do
+        runParser (optional $ bint token) (BInt 1) 
+            `shouldBe` Right (Just 1)
+        runParser (optional $ bint token) (BString "foo")
+            `shouldBe` Right Nothing
+    it "parses optional BStrings" $ do
+        runParser (optional $ bstring token) (BInt 1) 
+            `shouldBe` Right Nothing
+        runParser (optional $ bstring token) (BString "foo")
+            `shouldBe` Right (Just "foo")
+    it "parses optional BDict keys" $ do
+        runParser (optional $ bint $ dict "foo")
+                  (BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)])
+            `shouldBe` Right (Just 1)
+        runParser (optional $ bint $ dict "foo")
+                  (BDict $ Map.fromList [("bar", BInt 2)])
+            `shouldBe` Right Nothing

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,4 +1,3 @@
-
 {-# LANGUAGE OverloadedStrings #-}
 
 import qualified Data.Map as Map


### PR DESCRIPTION
Closes #2. Note that this changes the API for BParser. A more conservative approach might be to deprecate the old "list" parser in favor of "list_" or something like it.

Tests included.
