### PR TITLE
Simplify BParser

### DIFF
--- a/src/Data/BEncode.hs
+++ b/src/Data/BEncode.hs
@@ -53,7 +53,7 @@ instance Binary BEncode where
                Just e  -> return e
                Nothing -> fail "Failed to parse BEncoded data"
 
--- Source possition is pretty useless in BEncoded data. FIXME
+-- Source position is pretty useless in BEncoded data. FIXME
 updatePos :: (SourcePos -> Token -> [Token] -> SourcePos)
 updatePos pos _ _ = pos
 

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -12,14 +12,12 @@
 module Data.BEncode.Parser
     ( BParser
     , runParser
-    , token
     , dict
     , list
     , optional
     , bstring
     , bbytestring
     , bint
-    , setInput
     , (<|>)
     ) where
 
@@ -27,6 +25,7 @@ module Data.BEncode.Parser
 import           Control.Applicative        hiding (optional)
 import           Control.Monad
 import           Data.BEncode
+import           Data.Either (rights)
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map                   as Map
 
@@ -37,79 +36,62 @@ instance Alternative BParser where
     (<|>) a b = a `mplus` b
 
 instance MonadPlus BParser where
-    mzero = BParser $ \_ -> Error "mzero"
-    mplus (BParser a) (BParser b) = BParser $ \st -> case a st of
-                                                       Error _err -> b st
-                                                       ok         -> ok
+    mzero = fail "mzero"
+    mplus (BParser a) (BParser b) = BParser $ \st ->
+        case a st of
+            Left _err -> b st
+            ok         -> ok
 
+type Reply = Either String
 
-runB :: BParser a -> BEncode -> Reply a
-runB (BParser b) = b
-
-data Reply a
-    = Ok a BEncode
-    | Error String
-
+runParser :: BParser a -> BEncode -> Reply a
+runParser (BParser b) = b
 
 instance Applicative BParser where
   pure = return
   (<*>) = ap
 
 instance Monad BParser where
-    (BParser p) >>= f = BParser $ \b -> case p b of
-                                          Ok a b' -> runB (f a) b'
-                                          Error str -> Error str
-    return val = BParser $ Ok val
-    fail str = BParser $ \_ -> Error str
+    (BParser p) >>= f = BParser $ \b ->
+        case p b of
+            Right a -> runParser (f a) b
+            Left str -> Left str
+    return result = BParser . const $ Right result
+    fail str = BParser . const $ Left str
 
 instance Functor BParser where
     fmap fn p = do a <- p
                    return (fn a)
 
-runParser :: BParser a -> BEncode -> Either String a
-runParser parser b = case runB parser b of
-                       Ok a _ -> Right a
-                       Error str -> Left str
-
-token :: BParser BEncode
-token = BParser $ \b -> Ok b b
-
-dict :: String -> BParser BEncode
-dict name = BParser $ \b -> case b of
-                              BDict bmap | Just code <- Map.lookup name bmap
-                                   -> Ok code b
-                              BDict _ -> Error $ "Name not found in dictionary: " ++ name
-                              _ -> Error $ "Not a dictionary: " ++ name
+dict :: String -> BParser a -> BParser a
+dict name p = BParser $ \b -> case b of
+    BDict bmap | Just code <- Map.lookup name bmap
+       -> runParser p code
+    BDict _ -> Left $ "Name not found in dictionary: " ++ name
+    _ -> Left $ "Not a dictionary: " ++ show b
 
 list :: BParser a -> BParser [a]
 list p
-    = BParser $ \lst -> case lst of
-          BList (bs) -> foldr (cat . runB p) (Ok [] (BList [])) bs
-          _ -> Error $ "Not a list: " ++ (show lst)
-    where cat (Ok v _) (Ok vs b) = Ok (v:vs) b
-          cat (Ok _ _) (Error str) = Error str
-          cat (Error str) _ = Error str
+    = BParser $ \b -> case b of
+        -- note that if the inner parser fails on a member of the list
+        -- we still yield the members that successfully parsed
+        BList bs -> return . rights $ map (runParser p) bs
+        _ -> Left $ "Not a list: " ++ show b
 
 optional :: BParser a -> BParser (Maybe a)
 optional p = liftM Just p <|> return Nothing
 
-bstring :: BParser BEncode -> BParser String
-bstring p = do b <- p
-               case b of
-                 BString str -> return (L.unpack str)
-                 _ -> fail $ "Expected BString, found: " ++ show b
+bstring :: BParser String
+bstring = BParser $ \b -> case b of
+    BString str -> return $ L.unpack str
+    _ -> fail $ "Expected BString, found: " ++ show b
 
-bbytestring :: BParser BEncode -> BParser L.ByteString
-bbytestring p = do b <- p
-                   case b of
-                     BString str -> return str
-                     _ -> fail $ "Expected BString, found: " ++ show b
+bbytestring :: BParser L.ByteString
+bbytestring = BParser $ \b -> case b of
+    BString str -> return str
+    _ -> fail $ "Expected BString, found: " ++ show b
 
-bint :: BParser BEncode -> BParser Integer
-bint p = do b <- p
-            case b of
-              BInt int -> return int
-              _ -> fail $ "Expected BInt, found: " ++ show b
-
-setInput :: BEncode -> BParser ()
-setInput b = BParser $ \_ -> Ok () b
+bint :: BParser Integer
+bint = BParser $ \b -> case b of
+    BInt int -> return int
+    _ -> fail $ "Expected BInt, found: " ++ show b

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -65,10 +65,10 @@ dict name (BParser p) = BParser $ \b -> case b of
     _ -> Left $ "Not a dictionary: " ++ show b
 
 list :: BParser a -> BParser [a]
+-- note that if the inner parser fails on a member of the list
+-- we still yield the members that successfully parsed
 list (BParser p)
     = BParser $ \b -> case b of
-        -- note that if the inner parser fails on a member of the list
-        -- we still yield the members that successfully parsed
         BList bs -> return . rights $ map p bs
         _ -> Left $ "Not a list: " ++ show b
 

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -60,7 +60,7 @@ instance Monad BParser where
     fail = BParser . const . fail
 
 instance Functor BParser where
-    fmap fn p = p >>= return . fn
+    fmap fn p = return . fn =<< p
 
 dict :: String -> BParser a -> BParser a
 dict name p = BParser $ \b -> case b of

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -56,8 +56,8 @@ instance Monad BParser where
         case p b of
             Right a -> runParser (f a) b
             Left str -> Left str
-    return result = BParser . const $ Right result
-    fail str = BParser . const $ Left str
+    return = BParser . const . Right
+    fail = BParser . const . Left
 
 instance Functor BParser where
     fmap fn p = do a <- p

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -56,12 +56,11 @@ instance Monad BParser where
         case p b of
             Right a -> runParser (f a) b
             Left str -> Left str
-    return = BParser . const . Right
-    fail = BParser . const . Left
+    return = BParser . const . return
+    fail = BParser . const . fail
 
 instance Functor BParser where
-    fmap fn p = do a <- p
-                   return (fn a)
+    fmap fn p = p >>= return . fn
 
 dict :: String -> BParser a -> BParser a
 dict name p = BParser $ \b -> case b of

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -30,8 +30,7 @@ import           Data.BEncode
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map                   as Map
 
-data BParser a
-    = BParser (BEncode -> Reply a)
+newtype BParser a = BParser (BEncode -> Reply a)
 
 instance Alternative BParser where
     empty = mzero

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -52,7 +52,7 @@ instance Applicative BParser where
 instance Monad BParser where
     BParser p >>= f = BParser $ \b -> p b >>= \res -> runParser (f res) b
     return = BParser . const . return
-    fail = BParser . const . fail
+    fail = BParser . const . Left
 
 instance Functor BParser where
     fmap f p = return . f =<< p
@@ -78,14 +78,14 @@ optional p = liftM Just p <|> return Nothing
 bstring :: BParser String
 bstring = BParser $ \b -> case b of
     BString str -> return $ L.unpack str
-    _ -> fail $ "Expected BString, found: " ++ show b
+    _ -> Left $ "Expected BString, found: " ++ show b
 
 bbytestring :: BParser L.ByteString
 bbytestring = BParser $ \b -> case b of
     BString str -> return str
-    _ -> fail $ "Expected BString, found: " ++ show b
+    _ -> Left $ "Expected BString, found: " ++ show b
 
 bint :: BParser Integer
 bint = BParser $ \b -> case b of
     BInt int -> return int
-    _ -> fail $ "Expected BInt, found: " ++ show b
+    _ -> Left $ "Expected BInt, found: " ++ show b

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -29,7 +29,7 @@ import           Data.Either (rights)
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map                   as Map
 
-newtype BParser a = BParser (BEncode -> Reply a)
+newtype BParser a = BParser (BEncode -> Either String a)
 
 instance Alternative BParser where
     empty = mzero
@@ -42,9 +42,7 @@ instance MonadPlus BParser where
             Left _err -> b st
             ok         -> ok
 
-type Reply = Either String
-
-runParser :: BParser a -> BEncode -> Reply a
+runParser :: BParser a -> BEncode -> Either String a
 runParser (BParser b) = b
 
 instance Applicative BParser where

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -7,7 +7,7 @@
 -- Stability   :  stable
 -- Portability :  portable
 --
--- A parsec style parser for BEncoded data
+-- Parser combinators for BEncoded data
 -----------------------------------------------------------------------------
 module Data.BEncode.Parser
     ( BParser

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-} -- orphan Arbitrary instance is fine
 
 import qualified Data.Map as Map
 

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -78,61 +78,58 @@ main = hspec $ do
 
   describe "Data.BEncode.Parser" $ do
     it "parses BInts" $
-        runParser (bint token) (BInt 42) `shouldBe` Right 42
+        runParser bint (BInt 42) `shouldBe` Right 42
     it "parses BStrings" $
-        runParser (bstring token) (BString "foo") `shouldBe` Right "foo"
+        runParser bstring (BString "foo") `shouldBe` Right "foo"
     it "parses BStrings with special characters in Haskell source" $
-        runParser (bbytestring token) (BString "café") `shouldBe` Right "café"
+        runParser bbytestring (BString "café") `shouldBe` Right "café"
     it "parses empty BLists" $
-        runParser (list token) (BList []) `shouldBe` Right []
-    it "parses BLists of BInts and BStrings" $
-        runParser (list token) (BList [BInt 1, BString "foo"])
-        `shouldBe` Right [BInt 1, BString "foo"]
-    it "parses BLists of Integers" $
-        runParser (list $ bint token) (BList [BInt 1, BInt 2])
+        runParser (list bint) (BList []) `shouldBe` Right []
+    it "parses BLists of BInts" $
+        runParser (list bint) (BList [BInt 1, BInt 2])
         `shouldBe` Right [1, 2]
-    it "parses BLists of Strings" $
-        runParser (list $ bstring token) (BList [BString "foo", BString "bar"])
+    it "parses BLists of BStrings" $
+        runParser (list bstring) (BList [BString "foo", BString "bar"])
         `shouldBe` Right ["foo", "bar"]
-    it "parses BLists of Strings into ByteStrings" $
-        runParser (list $ bbytestring token) 
+    it "parses BLists of BStrings into ByteStrings" $
+        runParser (list bbytestring) 
                   (BList [BString "foo", BString "bar"])
         `shouldBe` Right ["foo", "bar"]
     it "parses nested BLists" $
-        runParser (list $ list $ bbytestring token)
+        runParser (list $ list bbytestring)
                   (BList [BList [BString "foo", BString "bar"], BList []])
         `shouldBe` Right [["foo", "bar"], []]
     it "parses BDicts" $
-        runParser (bint $ dict "foo")
+        runParser (dict "foo" bint)
                   (BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)])
         `shouldBe` Right 1
     it "parses BLists of BDicts" $
-        runParser (list $ dict "foo")
+        runParser (list $ dict "foo" bstring)
                   (BList [
-                    BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)],
+                    BDict $ Map.fromList [("foo", BString "bar"),
+                                          ("baz", BInt 2)],
                     BDict $ Map.singleton "foo" (BString "bam")
                   ])
-        `shouldBe` Right [BInt 1, BString "bam"]
+        `shouldBe` Right ["bar", "bam"]
     it "parses BDicts of BLists" $
-        runParser (dict "foo" >>= setInput >> list (bstring token))
+        runParser (dict "foo" $ list $ bstring)
                   (BDict $ Map.singleton "foo" (BList [
                     BString "foo", BString "bar"
                   ]))
         `shouldBe` Right ["foo", "bar"]
     it "parses optional BInts" $ do
-        runParser (optional $ bint token) (BInt 1) 
+        runParser (optional bint) (BInt 1) 
             `shouldBe` Right (Just 1)
-        runParser (optional $ bint token) (BString "foo")
+        runParser (optional bint) (BString "foo")
             `shouldBe` Right Nothing
     it "parses optional BStrings" $ do
-        runParser (optional $ bstring token) (BInt 1) 
-            `shouldBe` Right Nothing
-        runParser (optional $ bstring token) (BString "foo")
+        runParser (optional bstring) (BInt 1) `shouldBe` Right Nothing
+        runParser (optional bstring) (BString "foo")
             `shouldBe` Right (Just "foo")
     it "parses optional BDict keys" $ do
-        runParser (optional $ bint $ dict "foo")
+        runParser (optional $ dict "foo" bint)
                   (BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)])
             `shouldBe` Right (Just 1)
-        runParser (optional $ bint $ dict "foo")
+        runParser (optional $ dict "foo" bint)
                   (BDict $ Map.fromList [("bar", BInt 2)])
             `shouldBe` Right Nothing

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -133,3 +133,11 @@ main = hspec $ do
         runParser (optional $ dict "foo" bint)
                   (BDict $ Map.fromList [("bar", BInt 2)])
             `shouldBe` Right Nothing
+    it "parses monadically" $ do
+        parse (BDict $ Map.fromList [("foo", BString "bar"), ("baz", BInt 1)])
+            `shouldBe` Right ("bar", 1)
+          where 
+        parse = runParser $ do
+            foo <- dict "foo" bstring
+            baz <- dict "baz" bint
+            return (foo, baz)


### PR DESCRIPTION
Attempting to imitate Parsec with BParser doesn't make sense. Parser combinators running on text need to treat their input as a gradually consumed string. Tokenized BEncode input doesn't act this way; we generally "pluck" data from a BEncoded dictionary rather than consume it linearly.

As a result, there is no sense in passing around unconsumed data as in Parsec-style parsers. The previous API made very little use of this ability. By getting rid of the “remainder” part of our parser’s data structure, we end up with a much simpler module.

The upshot for API users:
- `bint token`, `bstring token`, `bbytestring token` become just `bint`, `bstring` and `bbytestring`.
- No more `token` primitive combinator. It's unnecessary.
- `bint $ dict "foo"` becomes `dict "foo" bint`
- No more `setInput`. It's unnecessary.

These changes are reflected in the tests, which should be more readable now.
