### PR TITLE
BReader reader monad

### DIFF
--- a/bencode.cabal
+++ b/bencode.cabal
@@ -40,6 +40,7 @@ Library
                     , containers
                     , binary
                     , mtl
+                    , transformers-compat >= 0.4
 
 test-suite doctests
   type:           exitcode-stdio-1.0

--- a/bencode.cabal
+++ b/bencode.cabal
@@ -38,7 +38,7 @@ Library
                     , bytestring
                     , containers
                     , binary
-                    , transformers
+                    , mtl
 
 test-suite spec
   ghc-options:    -Wall

--- a/bencode.cabal
+++ b/bencode.cabal
@@ -33,6 +33,7 @@ Library
   Exposed-Modules:    Data.BEncode
                       Data.BEncode.Lexer
                       Data.BEncode.Reader
+                      Data.BEncode.Parser
   Build-Depends:      base<5
                     , parsec
                     , bytestring

--- a/bencode.cabal
+++ b/bencode.cabal
@@ -40,6 +40,7 @@ Library
                     , containers
                     , binary
                     , transformers
+                    -- needed to support transformers 0.3.0.0
                     , transformers-compat >= 0.4
 
 test-suite doctests

--- a/bencode.cabal
+++ b/bencode.cabal
@@ -39,7 +39,6 @@ Library
                     , bytestring
                     , containers
                     , binary
-                    , mtl
                     , transformers
                     , transformers-compat >= 0.4
 

--- a/bencode.cabal
+++ b/bencode.cabal
@@ -38,6 +38,7 @@ Library
                     , bytestring
                     , containers
                     , binary
+                    , transformers
 
 test-suite spec
   ghc-options:    -Wall

--- a/bencode.cabal
+++ b/bencode.cabal
@@ -40,6 +40,7 @@ Library
                     , containers
                     , binary
                     , mtl
+                    , transformers
                     , transformers-compat >= 0.4
 
 test-suite doctests

--- a/bencode.cabal
+++ b/bencode.cabal
@@ -41,6 +41,15 @@ Library
                     , binary
                     , mtl
 
+test-suite doctests
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: tests
+  main-is:        doctests.hs
+  Default-Language:   Haskell2010
+  build-depends:  base == 4.*
+                , doctest >= 0.8
+                , bencode
+
 test-suite spec
   ghc-options:    -Wall
   type:           exitcode-stdio-1.0

--- a/bencode.cabal
+++ b/bencode.cabal
@@ -32,7 +32,7 @@ Library
   Default-Language:   Haskell2010
   Exposed-Modules:    Data.BEncode
                       Data.BEncode.Lexer
-                      Data.BEncode.Parser
+                      Data.BEncode.Reader
   Build-Depends:      base<5
                     , parsec
                     , bytestring

--- a/src/Data/BEncode.hs
+++ b/src/Data/BEncode.hs
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------
 -- |
--- Module      :  BEncode
+-- Module      :  Data.BEncode
 -- Copyright   :  (c) 2005 Jesper Louis Andersen <jlouis@mongers.org>
 --                    2006 Lemmih <lemmih@gmail.com>
 -- License     :  BSD3

--- a/src/Data/BEncode/Lexer.hs
+++ b/src/Data/BEncode/Lexer.hs
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------
 -- |
--- Module      :  BEncode.Lexer
+-- Module      :  Data.BEncode.Lexer
 -- Copyright   :  (c) 2005 Jesper Louis Andersen <jlouis@mongers.org>
 --                    2006 Lemmih <lemmih@gmail.com>
 -- License     :  BSD3

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -43,8 +43,8 @@ instance MonadPlus BParser where
             ok         -> ok
 
 instance Applicative BParser where
-  pure = return
-  (<*>) = ap
+    pure = return
+    (<*>) = ap
 
 instance Monad BParser where
     BParser p >>= f = BParser $ \b -> p b >>= \res -> runParser (f res) b

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -1,0 +1,117 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  BParser
+-- Copyright   :  (c) 2005 Lemmih <lemmih@gmail.com>
+-- License     :  BSD3
+-- Maintainer  :  lemmih@gmail.com
+-- Stability   :  stable
+-- Portability :  portable
+--
+-- A parsec style parser for BEncoded data
+-----------------------------------------------------------------------------
+module Data.BEncode.Parser {-# DEPRECATED "Use Data.BEncode.Reader instead" #-}
+    ( BParser
+    , runParser
+    , token
+    , dict
+    , list
+    , optional
+    , bstring
+    , bbytestring
+    , bint
+    , setInput
+    , (<|>)
+    ) where
+
+
+import           Control.Applicative        hiding (optional)
+import           Control.Monad
+import           Data.BEncode
+import qualified Data.ByteString.Lazy.Char8 as L
+import qualified Data.Map                   as Map
+
+data BParser a
+    = BParser (BEncode -> Reply a)
+
+instance Alternative BParser where
+    empty = mzero
+    (<|>) a b = a `mplus` b
+
+instance MonadPlus BParser where
+    mzero = BParser $ \_ -> Error "mzero"
+    mplus (BParser a) (BParser b) = BParser $ \st -> case a st of
+                                                       Error _err -> b st
+                                                       ok         -> ok
+
+
+runB :: BParser a -> BEncode -> Reply a
+runB (BParser b) = b
+
+data Reply a
+    = Ok a BEncode
+    | Error String
+
+
+instance Applicative BParser where
+  pure = return
+  (<*>) = ap
+
+instance Monad BParser where
+    (BParser p) >>= f = BParser $ \b -> case p b of
+                                          Ok a b' -> runB (f a) b'
+                                          Error str -> Error str
+    return val = BParser $ Ok val
+    fail str = BParser $ \_ -> Error str
+
+instance Functor BParser where
+    fmap fn p = do a <- p
+                   return (fn a)
+
+runParser :: BParser a -> BEncode -> Either String a
+runParser parser b = case runB parser b of
+                       Ok a _ -> Right a
+                       Error str -> Left str
+
+token :: BParser BEncode
+token = BParser $ \b -> Ok b b
+
+dict :: String -> BParser BEncode
+dict name = BParser $ \b -> case b of
+                              BDict bmap | Just code <- Map.lookup name bmap
+                                   -> Ok code b
+                              BDict _ -> Error $ "Name not found in dictionary: " ++ name
+                              _ -> Error $ "Not a dictionary: " ++ name
+
+list :: String -> BParser a -> BParser [a]
+list name p
+    = dict name >>= \lst ->
+      BParser $ \b -> case lst of
+                      BList bs -> foldr (cat . runB p) (Ok [] b) bs
+                      _ -> Error $ "Not a list: " ++ name
+    where cat (Ok v _) (Ok vs b) = Ok (v:vs) b
+          cat (Ok _ _) (Error str) = Error str
+          cat (Error str) _ = Error str
+
+optional :: BParser a -> BParser (Maybe a)
+optional p = liftM Just p <|> return Nothing
+
+bstring :: BParser BEncode -> BParser String
+bstring p = do b <- p
+               case b of
+                 BString str -> return (L.unpack str)
+                 _ -> fail $ "Expected BString, found: " ++ show b
+
+bbytestring :: BParser BEncode -> BParser L.ByteString
+bbytestring p = do b <- p
+                   case b of
+                     BString str -> return str
+                     _ -> fail $ "Expected BString, found: " ++ show b
+
+bint :: BParser BEncode -> BParser Integer
+bint p = do b <- p
+            case b of
+              BInt int -> return int
+              _ -> fail $ "Expected BInt, found: " ++ show b
+
+setInput :: BEncode -> BParser ()
+setInput b = BParser $ \_ -> Ok () b

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -9,7 +9,8 @@
 --
 -- A parsec style parser for BEncoded data
 -----------------------------------------------------------------------------
-module Data.BEncode.Parser {-# DEPRECATED "Use Data.BEncode.Reader instead" #-}
+module Data.BEncode.Parser {-#
+    DEPRECATED "Use \"Data.BEncode.Reader\" instead" #-}
     ( BParser
     , runParser
     , token

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -67,20 +67,6 @@ instance Functor BParser where
     fmap = liftM
 
 
-dict :: String -> BParser a -> BParser a
-dict name (BParser p) = BParser $ \b -> case b of
-    BDict bmap | (Just code) <- Map.lookup name bmap -> p code
-    BDict _ -> Left $ "Name not found in dictionary: " ++ name
-    _ -> Left $ "Not a dictionary: " ++ show b
-
-list :: BParser a -> BParser [a]
-list (BParser p)
-    = BParser $ \b -> case b of
-        BList bs -> sequenceA $ map p bs
-        _ -> Left $ "Not a list: " ++ show b
-    fmap fn p = do a <- p
-                   return (fn a)
-
 runParser :: BParser a -> BEncode -> Either String a
 runParser parser b = case runB parser b of
                        Ok a _ -> Right a

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -14,10 +14,7 @@ module Data.BEncode.Parser
     , runReader
     , dict
     , list
-    {-
     , optional
-    , (<|>)
-    -}
     , bstring
     , bbytestring
     , bint
@@ -48,10 +45,10 @@ list br = reader $ \b -> case b of
     BList bs -> return . rights $ map (runReader br) bs
     _ -> Left $ "Not a list: " ++ show b
 
-{-
 optional :: BReader a -> BReader (Maybe a)
-optional br = (fmap Just) br <|> return Nothing
--}
+optional br = reader $ \b -> case runReader br b of
+    Right result -> return $ Just result
+    _ -> return $ Nothing
 
 bstring :: BReader String
 bstring = reader $ \b -> case b of

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -32,8 +32,8 @@ import qualified Data.Map                   as Map
 newtype BParser a = BParser {runParser :: (BEncode -> Either String a)}
 
 instance Alternative BParser where
+    (<|>) = mplus
     empty = mzero
-    (<|>) a b = a `mplus` b
 
 instance MonadPlus BParser where
     mzero = fail "mzero"
@@ -52,7 +52,7 @@ instance Monad BParser where
     fail = BParser . const . Left
 
 instance Functor BParser where
-    fmap f p = return . f =<< p
+    fmap = liftM
 
 
 dict :: String -> BParser a -> BParser a

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -14,22 +14,21 @@ module Data.BEncode.Parser
     , runReader
     , dict
     , list
-    , optional
     , bstring
     , bbytestring
     , bint
+    , optional
+    , (<|>)
     ) where
 
 
-import           Control.Applicative        hiding (optional)
-import           Control.Monad
+import           Control.Applicative        (optional, (<|>))
 import           Control.Monad.Trans.Reader (Reader, reader, runReader)
 import           Data.BEncode
 import           Data.Either (rights)
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map                   as Map
 
---newtype BParser a = BParser (BEncode -> Either String a)
 type BReader a = Reader BEncode (Either String a)
 
 dict :: String -> BReader a -> BReader a
@@ -44,11 +43,6 @@ list :: BReader a -> BReader [a]
 list br = reader $ \b -> case b of
     BList bs -> return . rights $ map (runReader br) bs
     _ -> Left $ "Not a list: " ++ show b
-
-optional :: BReader a -> BReader (Maybe a)
-optional br = reader $ \b -> case runReader br b of
-    Right result -> return $ Just result
-    _ -> return $ Nothing
 
 bstring :: BReader String
 bstring = reader $ \b -> case b of

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -12,7 +12,7 @@
 -----------------------------------------------------------------------------
 module Data.BEncode.Reader
     ( BReader
-    , runReader
+    , runBReader
     , dict
     , list
     , bstring

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -36,7 +36,8 @@ module Data.BEncode.Reader (
     ) where
 
 import           Control.Applicative        (Applicative, Alternative)
-import           Control.Monad.Reader
+import           Control.Monad              (MonadPlus)
+import           Control.Monad.Trans.Reader
 import           Control.Monad.Trans.Except
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map                   as Map
@@ -47,8 +48,7 @@ import           Data.BEncode
 -----------------------------------------------------------------------------
 
 newtype BReader a = BReader (ExceptT String (Reader BEncode) a)
-    deriving (Functor, Applicative, Alternative, Monad, MonadPlus,
-              MonadReader BEncode)
+    deriving (Functor, Applicative, Alternative, Monad, MonadPlus)
 -- ^Reader monad for extracting data from a BEncoded structure.
 
 breader :: (BEncode -> (Either String a)) -> BReader a

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -19,10 +19,9 @@ module Data.BEncode.Reader
     , bbytestring
     , bint
     , optional
-    , (<|>)
     ) where
 
-import           Control.Applicative        (Applicative, Alternative, (<|>))
+import           Control.Applicative        (Applicative, Alternative)
 import           Control.Monad.Reader
 import           Control.Monad.Error
 import           Data.Traversable           (sequenceA)

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -35,7 +35,7 @@ module Data.BEncode.Reader (
     bint, bbytestring, bstring, optional, list, dict
     ) where
 
-import           Control.Applicative hiding (optional)
+import           Control.Applicative
 import           Control.Monad              (MonadPlus)
 import           Control.Monad.Trans.Reader
 import           Control.Monad.Trans.Except
@@ -84,24 +84,6 @@ bint = breader $ \b -> case b of
 -- >>> runBReader bint (BInt 42)
 -- Right 42
 --
-
-optional :: BReader a -> BReader (Maybe a)
-optional br = breader $ \b -> case runBReader br b of
-    Right x -> Right $ Just x
-    _ -> Right Nothing
--- ^ Wrap a BReader's result in a Maybe and never fail.
---
--- >>> runBReader (optional bint) (BInt 1) 
--- Right (Just 1)
---
--- >>> runBReader (optional bint) (BString "foo")
--- Right Nothing
---
--- >>> runBReader (optional bstring) (BInt 1)
--- Right Nothing
---
--- >>> runBReader (optional bstring) (BString "foo")
--- Right (Just "foo")
 
 list :: BReader a -> BReader [a]
 list br = breader $ \b -> case b of

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -15,9 +15,9 @@
 --
 -- Usage example:
 --
->>> :set -XOverloadedStrings
->>> let bd = (BDict $ Map.fromList [("foo", BString "bar"), ("baz", BInt 1)])
->>> :{
+-- >>> :set -XOverloadedStrings
+-- >>> let bd = (BDict $ Map.fromList [("foo", BString "bar"), ("baz", BInt 1)])
+-- >>> :{
 -- let bReader = do
 --       foo <- dict "foo" bstring
 --       baz <- dict "baz" bint

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -38,7 +38,6 @@ module Data.BEncode.Reader (
 import           Control.Applicative        (Applicative, Alternative)
 import           Control.Monad.Reader
 import           Control.Monad.Error
-import           Data.Traversable           (sequenceA)
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map                   as Map
 
@@ -108,7 +107,7 @@ optional br = breader $ \b -> case runBReader br b of
 
 list :: BReader a -> BReader [a]
 list br = breader $ \b -> case b of
-    BList bs -> sequenceA $ map (runBReader br) bs
+    BList bs -> mapM (runBReader br) bs
     _ -> Left $ "Not a list: " ++ show b
 -- ^ Read a list of BEncoded data
 --

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -23,9 +23,8 @@ module Data.BEncode.Reader
     ) where
 
 import           Control.Applicative        (Applicative, Alternative, (<|>))
-import           Control.Monad              (MonadPlus)
-import           Control.Monad.Trans.Reader (Reader, reader, runReader)
-import           Control.Monad.Trans.Error  (ErrorT(..), runErrorT)
+import           Control.Monad.Reader
+import           Control.Monad.Error
 import           Data.Traversable           (sequenceA)
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map                   as Map
@@ -33,7 +32,8 @@ import qualified Data.Map                   as Map
 import           Data.BEncode
 
 newtype BReader a = BReader (ErrorT String (Reader BEncode) a)
-    deriving (Functor, Applicative, Alternative, Monad, MonadPlus)
+    deriving (Functor, Applicative, Alternative, Monad, MonadPlus,
+              MonadReader BEncode, MonadError String)
 
 breader :: (BEncode -> (Either String a)) -> BReader a
 breader = BReader . ErrorT . reader

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -5,7 +5,7 @@
 -- Copyright   :  (c) 2015 Matthew Leon <ml@matthewleon.com>
 -- License     :  BSD3
 -- Maintainer  :  lemmih@gmail.com
--- Stability   :  stable
+-- Stability   :  experimental
 -- Portability :  portable
 --
 -- A reader monad for BEncoded data

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -1,24 +1,37 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# OPTIONS_HADDOCK show-extensions #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.BEncode.Reader
 -- Copyright   :  (c) 2015 Matthew Leon <ml@matthewleon.com>
 -- License     :  BSD3
--- Maintainer  :  lemmih@gmail.com
+-- Maintainer  :  creichert07@gmail.com
 -- Stability   :  experimental
 -- Portability :  portable
 --
--- A reader monad for BEncoded data
+-- Reader monad and combinators for BEncoded data.
+--
+-- This is intended to replace the older "Data.BEncode.Parser" module.
+--
+-- Usage example:
+--
+-- >>> :set -XOverloadedStrings
+-- >>> :{
+-- let bd = (BDict $ Map.fromList [("foo", BString "bar"), ("baz", BInt 1)])
+--     bReader = do
+--     foo <- dict "foo" bstring
+--     baz <- dict "baz" bint
+--     shouldBeNothing <- optional $ dict "optionalKey" bint
+--     return (foo, baz, shouldBeNothing)
+-- in runBReader bReader bd
+-- :}
+-- Right ("bar",1,Nothing)
 -----------------------------------------------------------------------------
-module Data.BEncode.Reader
-    ( BReader
-    , runBReader
-    , dict
-    , list
-    , bstring
-    , bbytestring
-    , bint
-    , optional
+module Data.BEncode.Reader (
+    -- * Monad
+    BReader, runBReader,
+    -- * Combinators
+    bint, bbytestring, bstring, optional, list, dict
     ) where
 
 import           Control.Applicative        (Applicative, Alternative)
@@ -33,38 +46,99 @@ import           Data.BEncode
 newtype BReader a = BReader (ErrorT String (Reader BEncode) a)
     deriving (Functor, Applicative, Alternative, Monad, MonadPlus,
               MonadReader BEncode, MonadError String)
+-- ^Reader monad for extracting data from a BEncoded structure.
 
 breader :: (BEncode -> (Either String a)) -> BReader a
 breader = BReader . ErrorT . reader
+-- ^BReader constructor. Private.
 
 runBReader :: BReader a -> BEncode -> Either String a
 runBReader (BReader br) = runReader $ runErrorT br
+-- ^Run a BReader. See usage examples elsewhere in this file.
+
+bbytestring :: BReader L.ByteString
+bbytestring = breader $ \b -> case b of
+    BString str -> return str
+    _ -> Left $ "Expected BString, found: " ++ show b
+-- ^
+-- >>> :set -XOverloadedStrings
+-- >>> runBReader bbytestring (BString "foo")
+-- Right "foo"
+
+bstring :: BReader String
+bstring = fmap L.unpack bbytestring
+-- ^
+-- >>> runBReader bstring (BString "foo")
+-- Right "foo"
+--
+
+bint :: BReader Integer
+bint = breader $ \b -> case b of
+    BInt int -> return int
+    _ -> Left $ "Expected BInt, found: " ++ show b
+-- ^
+-- >>> runBReader bint (BInt 42)
+-- Right 42
+--
+
+optional :: BReader a -> BReader (Maybe a)
+optional br = breader $ \b -> case runBReader br b of
+    Right x -> Right $ Just x
+    _ -> Right Nothing
+-- ^ Wrap a BReader's result in a Maybe and never fail.
+--
+-- >>> runBReader (optional bint) (BInt 1) 
+-- Right (Just 1)
+--
+-- >>> runBReader (optional bint) (BString "foo")
+-- Right Nothing
+--
+-- >>> runBReader (optional bstring) (BInt 1)
+-- Right Nothing
+--
+-- >>> runBReader (optional bstring) (BString "foo")
+-- Right (Just "foo")
+
+list :: BReader a -> BReader [a]
+list br = breader $ \b -> case b of
+    BList bs -> sequenceA $ map (runBReader br) bs
+    _ -> Left $ "Not a list: " ++ show b
+-- ^ Read a list of BEncoded data
+--
+-- >>> runBReader (list bint) (BList [BInt 1, BInt 2])
+-- Right [1,2]
+--
+-- >>> runBReader (list bint) (BList [])
+-- Right []
+--
+-- >>> let bs = (BList [BList [BString "foo", BString "bar"], BList []])
+-- >>> runBReader (list $ list bbytestring) bs
+-- Right [["foo","bar"],[]]
 
 dict :: String -> BReader a -> BReader a
 dict name br = breader $ \b -> case b of
     BDict bmap | (Just code) <- Map.lookup name bmap -> runBReader br code
     BDict _ -> Left $ "Name not found in dictionary: " ++ name
     _ -> Left $ "Not a dictionary: " ++ show b
-
-list :: BReader a -> BReader [a]
-list br = breader $ \b -> case b of
-    BList bs -> sequenceA $ map (runBReader br) bs
-    _ -> Left $ "Not a list: " ++ show b
-
-optional :: BReader a -> BReader (Maybe a)
-optional br = breader $ \b -> case runBReader br b of
-    Right x -> Right $ Just x
-    _ -> Right Nothing
-
-bbytestring :: BReader L.ByteString
-bbytestring = breader $ \b -> case b of
-    BString str -> return str
-    _ -> Left $ "Expected BString, found: " ++ show b
-
-bstring :: BReader String
-bstring = fmap L.unpack bbytestring
-
-bint :: BReader Integer
-bint = breader $ \b -> case b of
-    BInt int -> return int
-    _ -> Left $ "Expected BInt, found: " ++ show b
+-- ^ Read the values of a BDict corresponding to a string key
+--
+-- >>> let bd = (BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)])
+-- >>> runBReader (dict "foo" bint) bd
+-- Right 1
+--
+--
+-- >>> :{
+-- let bs = (BList [BDict $ Map.fromList [("foo", BString "bar"),
+--                                       ("baz", BInt 2)],
+--                  BDict $ Map.singleton "foo" (BString "bam")])
+-- in runBReader (list $ dict "foo" bstring) bs
+-- :}
+-- Right ["bar","bam"]
+--
+-- >>> :{
+-- let bd = (BDict $ Map.singleton "foo" (BList [
+--             BString "foo", BString "bar"
+--          ]))
+-- in runBReader (dict "foo" $ list $ bstring) bd
+-- :}
+-- Right ["foo","bar"]

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -44,6 +44,9 @@ import qualified Data.Map                   as Map
 
 import           Data.BEncode
 
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
 newtype BReader a = BReader (ErrorT String (Reader BEncode) a)
     deriving (Functor, Applicative, Alternative, Monad, MonadPlus,
               MonadReader BEncode, MonadError String)
@@ -57,6 +60,7 @@ runBReader :: BReader a -> BEncode -> Either String a
 runBReader (BReader br) = runReader $ runErrorT br
 -- ^Run a BReader. See usage examples elsewhere in this file.
 
+-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------
 
 bbytestring :: BReader L.ByteString

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -15,14 +15,14 @@
 --
 -- Usage example:
 --
--- >>> :set -XOverloadedStrings
--- >>> :{
--- let bd = (BDict $ Map.fromList [("foo", BString "bar"), ("baz", BInt 1)])
---     bReader = do
---     foo <- dict "foo" bstring
---     baz <- dict "baz" bint
---     shouldBeNothing <- optional $ dict "optionalKey" bint
---     return (foo, baz, shouldBeNothing)
+>>> :set -XOverloadedStrings
+>>> let bd = (BDict $ Map.fromList [("foo", BString "bar"), ("baz", BInt 1)])
+>>> :{
+-- let bReader = do
+--       foo <- dict "foo" bstring
+--       baz <- dict "baz" bint
+--       shouldBeNothing <- optional $ dict "optionalKey" bint
+--       return (foo, baz, shouldBeNothing)
 -- in runBReader bReader bd
 -- :}
 -- Right ("bar",1,Nothing)

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -2,7 +2,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.BEncode.Reader
--- Copyright   :  (c) 2005 Lemmih <lemmih@gmail.com>
+-- Copyright   :  (c) 2015 Matthew Leon <ml@matthewleon.com>
 -- License     :  BSD3
 -- Maintainer  :  lemmih@gmail.com
 -- Stability   :  stable

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -37,7 +37,7 @@ module Data.BEncode.Reader (
 
 import           Control.Applicative        (Applicative, Alternative)
 import           Control.Monad.Reader
-import           Control.Monad.Error
+import           Control.Monad.Trans.Except
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map                   as Map
 
@@ -46,17 +46,17 @@ import           Data.BEncode
 -----------------------------------------------------------------------------
 -----------------------------------------------------------------------------
 
-newtype BReader a = BReader (ErrorT String (Reader BEncode) a)
+newtype BReader a = BReader (ExceptT String (Reader BEncode) a)
     deriving (Functor, Applicative, Alternative, Monad, MonadPlus,
-              MonadReader BEncode, MonadError String)
+              MonadReader BEncode)
 -- ^Reader monad for extracting data from a BEncoded structure.
 
 breader :: (BEncode -> (Either String a)) -> BReader a
-breader = BReader . ErrorT . reader
+breader = BReader . ExceptT . reader
 -- ^BReader constructor. Private.
 
 runBReader :: BReader a -> BEncode -> Either String a
-runBReader (BReader br) = runReader $ runErrorT br
+runBReader (BReader br) = runReader $ runExceptT br
 -- ^Run a BReader. See usage examples elsewhere in this file.
 
 -----------------------------------------------------------------------------

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -116,7 +116,7 @@ list br = breader $ \b -> case b of
 -- Right []
 --
 -- >>> let bs = (BList [BList [BString "foo", BString "bar"], BList []])
--- >>> runBReader (list $ list string) bs
+-- >>> runBReader (list $ list bstring) bs
 -- Right [["foo","bar"],[]]
 
 dict :: String -> BReader a -> BReader a

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -28,7 +28,7 @@
 -- Right ("bar",1,Nothing)
 -----------------------------------------------------------------------------
 module Data.BEncode.Reader (
-    -- * Monad
+    -- * Reader Monad
     BReader, runBReader,
     -- * Combinators
     bint, bbytestring, bstring, optional, list, dict

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -27,6 +27,7 @@
 -- :}
 -- Right ("bar",1,Nothing)
 -----------------------------------------------------------------------------
+
 module Data.BEncode.Reader (
     -- * Reader Monad
     BReader, runBReader,
@@ -55,6 +56,8 @@ breader = BReader . ErrorT . reader
 runBReader :: BReader a -> BEncode -> Either String a
 runBReader (BReader br) = runReader $ runErrorT br
 -- ^Run a BReader. See usage examples elsewhere in this file.
+
+-----------------------------------------------------------------------------
 
 bbytestring :: BReader L.ByteString
 bbytestring = breader $ \b -> case b of

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -35,7 +35,7 @@ module Data.BEncode.Reader (
     bint, bbytestring, bstring, optional, list, dict
     ) where
 
-import           Control.Applicative        (Applicative, Alternative)
+import           Control.Applicative hiding (optional)
 import           Control.Monad              (MonadPlus)
 import           Control.Monad.Trans.Reader
 import           Control.Monad.Trans.Except

--- a/src/Data/BEncode/Reader.hs
+++ b/src/Data/BEncode/Reader.hs
@@ -66,10 +66,8 @@ bbytestring :: BReader L.ByteString
 bbytestring = breader $ \b -> case b of
     BString str -> return str
     _ -> Left $ "Expected BString, found: " ++ show b
--- ^
--- >>> :set -XOverloadedStrings
--- >>> runBReader bbytestring (BString "foo")
--- Right "foo"
+-- ^ Usage same as bstring, below.
+-- (sadly, doctests for this cause errors on GHC 7.4)
 
 bstring :: BReader String
 bstring = fmap L.unpack bbytestring
@@ -118,7 +116,7 @@ list br = breader $ \b -> case b of
 -- Right []
 --
 -- >>> let bs = (BList [BList [BString "foo", BString "bar"], BList []])
--- >>> runBReader (list $ list bbytestring) bs
+-- >>> runBReader (list $ list string) bs
 -- Right [["foo","bar"],[]]
 
 dict :: String -> BReader a -> BReader a

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -7,7 +7,6 @@ import Test.Hspec
 import Test.QuickCheck
 
 import Data.BEncode
-import Data.BEncode.Reader
 import Data.ByteString.Lazy (pack)
 
 instance Arbitrary BEncode where arbitrary = sized bencode'
@@ -76,69 +75,3 @@ main = hspec $ do
     it "decodes lists of lists" $
         bRead "l5:helloi42eli-1ei0ei1ei2ei3e4:fouree"
             `shouldBe` Just (BList [ BString "hello", BInt 42, bll])
-
-  describe "Data.BEncode.Parser" $ do
-    it "parses BInts" $
-        runBReader bint (BInt 42) `shouldBe` Right 42
-    it "parses BStrings" $
-        runBReader bstring (BString "foo") `shouldBe` Right "foo"
-    it "parses BStrings with special characters in Haskell source" $
-        runBReader bbytestring (BString "café") `shouldBe` Right "café"
-    it "parses empty BLists" $
-        runBReader (list bint) (BList []) `shouldBe` Right []
-    it "parses BLists of BInts" $
-        runBReader (list bint) (BList [BInt 1, BInt 2])
-        `shouldBe` Right [1, 2]
-    it "parses BLists of BStrings" $
-        runBReader (list bstring) (BList [BString "foo", BString "bar"])
-        `shouldBe` Right ["foo", "bar"]
-    it "parses BLists of BStrings into ByteStrings" $
-        runBReader (list bbytestring) 
-                  (BList [BString "foo", BString "bar"])
-        `shouldBe` Right ["foo", "bar"]
-    it "parses nested BLists" $
-        runBReader (list $ list bbytestring)
-                  (BList [BList [BString "foo", BString "bar"], BList []])
-        `shouldBe` Right [["foo", "bar"], []]
-    it "parses BDicts" $
-        runBReader (dict "foo" bint)
-                  (BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)])
-        `shouldBe` Right 1
-    it "parses BLists of BDicts" $
-        runBReader (list $ dict "foo" bstring)
-                  (BList [
-                    BDict $ Map.fromList [("foo", BString "bar"),
-                                          ("baz", BInt 2)],
-                    BDict $ Map.singleton "foo" (BString "bam")
-                  ])
-        `shouldBe` Right ["bar", "bam"]
-    it "parses BDicts of BLists" $
-        runBReader (dict "foo" $ list $ bstring)
-                  (BDict $ Map.singleton "foo" (BList [
-                    BString "foo", BString "bar"
-                  ]))
-        `shouldBe` Right ["foo", "bar"]
-    it "parses optional BInts" $ do
-        runBReader (optional bint) (BInt 1) 
-            `shouldBe` Right (Just 1)
-        runBReader (optional bint) (BString "foo")
-            `shouldBe` Right Nothing
-    it "parses optional BStrings" $ do
-        runBReader (optional bstring) (BInt 1) `shouldBe` Right Nothing
-        runBReader (optional bstring) (BString "foo")
-            `shouldBe` Right (Just "foo")
-    it "parses optional BDict keys" $ do
-        runBReader (optional $ dict "foo" bint)
-                  (BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)])
-            `shouldBe` Right (Just 1)
-        runBReader (optional $ dict "foo" bint)
-                  (BDict $ Map.fromList [("bar", BInt 2)])
-            `shouldBe` Right Nothing
-    it "parses monadically" $ do
-        parse (BDict $ Map.fromList [("foo", BString "bar"), ("baz", BInt 1)])
-            `shouldBe` Right ("bar", 1)
-          where 
-        parse = runBReader $ do
-            foo <- dict "foo" bstring
-            baz <- dict "baz" bint
-            return (foo, baz)

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -79,33 +79,33 @@ main = hspec $ do
 
   describe "Data.BEncode.Parser" $ do
     it "parses BInts" $
-        runReader bint (BInt 42) `shouldBe` Right 42
+        runBReader bint (BInt 42) `shouldBe` Right 42
     it "parses BStrings" $
-        runReader bstring (BString "foo") `shouldBe` Right "foo"
+        runBReader bstring (BString "foo") `shouldBe` Right "foo"
     it "parses BStrings with special characters in Haskell source" $
-        runReader bbytestring (BString "café") `shouldBe` Right "café"
+        runBReader bbytestring (BString "café") `shouldBe` Right "café"
     it "parses empty BLists" $
-        runReader (list bint) (BList []) `shouldBe` Right []
+        runBReader (list bint) (BList []) `shouldBe` Right []
     it "parses BLists of BInts" $
-        runReader (list bint) (BList [BInt 1, BInt 2])
+        runBReader (list bint) (BList [BInt 1, BInt 2])
         `shouldBe` Right [1, 2]
     it "parses BLists of BStrings" $
-        runReader (list bstring) (BList [BString "foo", BString "bar"])
+        runBReader (list bstring) (BList [BString "foo", BString "bar"])
         `shouldBe` Right ["foo", "bar"]
     it "parses BLists of BStrings into ByteStrings" $
-        runReader (list bbytestring) 
+        runBReader (list bbytestring) 
                   (BList [BString "foo", BString "bar"])
         `shouldBe` Right ["foo", "bar"]
     it "parses nested BLists" $
-        runReader (list $ list bbytestring)
+        runBReader (list $ list bbytestring)
                   (BList [BList [BString "foo", BString "bar"], BList []])
         `shouldBe` Right [["foo", "bar"], []]
     it "parses BDicts" $
-        runReader (dict "foo" bint)
+        runBReader (dict "foo" bint)
                   (BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)])
         `shouldBe` Right 1
     it "parses BLists of BDicts" $
-        runReader (list $ dict "foo" bstring)
+        runBReader (list $ dict "foo" bstring)
                   (BList [
                     BDict $ Map.fromList [("foo", BString "bar"),
                                           ("baz", BInt 2)],
@@ -113,32 +113,32 @@ main = hspec $ do
                   ])
         `shouldBe` Right ["bar", "bam"]
     it "parses BDicts of BLists" $
-        runReader (dict "foo" $ list $ bstring)
+        runBReader (dict "foo" $ list $ bstring)
                   (BDict $ Map.singleton "foo" (BList [
                     BString "foo", BString "bar"
                   ]))
         `shouldBe` Right ["foo", "bar"]
     it "parses optional BInts" $ do
-        runReader (optional bint) (BInt 1) 
+        runBReader (optional bint) (BInt 1) 
             `shouldBe` Right (Just 1)
-        runReader (optional bint) (BString "foo")
+        runBReader (optional bint) (BString "foo")
             `shouldBe` Right Nothing
     it "parses optional BStrings" $ do
-        runReader (optional bstring) (BInt 1) `shouldBe` Right Nothing
-        runReader (optional bstring) (BString "foo")
+        runBReader (optional bstring) (BInt 1) `shouldBe` Right Nothing
+        runBReader (optional bstring) (BString "foo")
             `shouldBe` Right (Just "foo")
     it "parses optional BDict keys" $ do
-        runReader (optional $ dict "foo" bint)
+        runBReader (optional $ dict "foo" bint)
                   (BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)])
             `shouldBe` Right (Just 1)
-        runReader (optional $ dict "foo" bint)
+        runBReader (optional $ dict "foo" bint)
                   (BDict $ Map.fromList [("bar", BInt 2)])
             `shouldBe` Right Nothing
     it "parses monadically" $ do
         parse (BDict $ Map.fromList [("foo", BString "bar"), ("baz", BInt 1)])
             `shouldBe` Right ("bar", 1)
           where 
-        parse = runReader $ do
+        parse = runBReader $ do
             foo <- dict "foo" bstring
             baz <- dict "baz" bint
             return (foo, baz)

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -7,7 +7,7 @@ import Test.Hspec
 import Test.QuickCheck
 
 import Data.BEncode
-import Data.BEncode.Parser
+import Data.BEncode.Reader
 import Data.ByteString.Lazy (pack)
 
 instance Arbitrary BEncode where arbitrary = sized bencode'
@@ -79,33 +79,33 @@ main = hspec $ do
 
   describe "Data.BEncode.Parser" $ do
     it "parses BInts" $
-        runParser bint (BInt 42) `shouldBe` Right 42
+        runReader bint (BInt 42) `shouldBe` Right 42
     it "parses BStrings" $
-        runParser bstring (BString "foo") `shouldBe` Right "foo"
+        runReader bstring (BString "foo") `shouldBe` Right "foo"
     it "parses BStrings with special characters in Haskell source" $
-        runParser bbytestring (BString "café") `shouldBe` Right "café"
+        runReader bbytestring (BString "café") `shouldBe` Right "café"
     it "parses empty BLists" $
-        runParser (list bint) (BList []) `shouldBe` Right []
+        runReader (list bint) (BList []) `shouldBe` Right []
     it "parses BLists of BInts" $
-        runParser (list bint) (BList [BInt 1, BInt 2])
+        runReader (list bint) (BList [BInt 1, BInt 2])
         `shouldBe` Right [1, 2]
     it "parses BLists of BStrings" $
-        runParser (list bstring) (BList [BString "foo", BString "bar"])
+        runReader (list bstring) (BList [BString "foo", BString "bar"])
         `shouldBe` Right ["foo", "bar"]
     it "parses BLists of BStrings into ByteStrings" $
-        runParser (list bbytestring) 
+        runReader (list bbytestring) 
                   (BList [BString "foo", BString "bar"])
         `shouldBe` Right ["foo", "bar"]
     it "parses nested BLists" $
-        runParser (list $ list bbytestring)
+        runReader (list $ list bbytestring)
                   (BList [BList [BString "foo", BString "bar"], BList []])
         `shouldBe` Right [["foo", "bar"], []]
     it "parses BDicts" $
-        runParser (dict "foo" bint)
+        runReader (dict "foo" bint)
                   (BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)])
         `shouldBe` Right 1
     it "parses BLists of BDicts" $
-        runParser (list $ dict "foo" bstring)
+        runReader (list $ dict "foo" bstring)
                   (BList [
                     BDict $ Map.fromList [("foo", BString "bar"),
                                           ("baz", BInt 2)],
@@ -113,32 +113,32 @@ main = hspec $ do
                   ])
         `shouldBe` Right ["bar", "bam"]
     it "parses BDicts of BLists" $
-        runParser (dict "foo" $ list $ bstring)
+        runReader (dict "foo" $ list $ bstring)
                   (BDict $ Map.singleton "foo" (BList [
                     BString "foo", BString "bar"
                   ]))
         `shouldBe` Right ["foo", "bar"]
     it "parses optional BInts" $ do
-        runParser (optional bint) (BInt 1) 
+        runReader (optional bint) (BInt 1) 
             `shouldBe` Right (Just 1)
-        runParser (optional bint) (BString "foo")
+        runReader (optional bint) (BString "foo")
             `shouldBe` Right Nothing
     it "parses optional BStrings" $ do
-        runParser (optional bstring) (BInt 1) `shouldBe` Right Nothing
-        runParser (optional bstring) (BString "foo")
+        runReader (optional bstring) (BInt 1) `shouldBe` Right Nothing
+        runReader (optional bstring) (BString "foo")
             `shouldBe` Right (Just "foo")
     it "parses optional BDict keys" $ do
-        runParser (optional $ dict "foo" bint)
+        runReader (optional $ dict "foo" bint)
                   (BDict $ Map.fromList [("foo", BInt 1), ("bar", BInt 2)])
             `shouldBe` Right (Just 1)
-        runParser (optional $ dict "foo" bint)
+        runReader (optional $ dict "foo" bint)
                   (BDict $ Map.fromList [("bar", BInt 2)])
             `shouldBe` Right Nothing
     it "parses monadically" $ do
         parse (BDict $ Map.fromList [("foo", BString "bar"), ("baz", BInt 1)])
             `shouldBe` Right ("bar", 1)
           where 
-        parse = runParser $ do
+        parse = runReader $ do
             foo <- dict "foo" bstring
             baz <- dict "baz" bint
             return (foo, baz)

--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -1,0 +1,2 @@
+import Test.DocTest
+main = doctest ["-isrc", "src/Data/BEncode/Reader.hs"]


### PR DESCRIPTION
Restores the old `BParser` with a note indicating it will be deprecated and introduces the new `BReader` module. This new module derives all its typeclass implementations from `mtl` and exposes a simple, minimal API. It is fully documented with included `docstring` style tests.

Resolves #7.
