### PR TITLE
Move fail method into MonadFail instance

### DIFF
--- a/bencode.cabal
+++ b/bencode.cabal
@@ -35,6 +35,7 @@ Library
                       Data.BEncode.Reader
                       Data.BEncode.Parser
   Build-Depends:      base<5
+                    , fail
                     , parsec
                     , bytestring
                     , containers

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -61,6 +61,8 @@ instance Monad BParser where
                                           Ok a b' -> runB (f a) b'
                                           Error str -> Error str
     return val = BParser $ Ok val
+
+instance MonadFail BParser where
     fail str = BParser $ \_ -> Error str
 
 instance Functor BParser where

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  BParser
@@ -27,6 +29,7 @@ module Data.BEncode.Parser {-#
 
 import           Control.Applicative        hiding (optional)
 import           Control.Monad
+import qualified Control.Monad.Fail         as Fail
 import           Data.BEncode
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map                   as Map
@@ -62,7 +65,11 @@ instance Monad BParser where
                                           Error str -> Error str
     return val = BParser $ Ok val
 
-instance MonadFail BParser where
+#if !(MIN_VERSION_base(4,13,0))
+    fail = Fail.fail
+#endif
+
+instance Fail.MonadFail BParser where
     fail str = BParser $ \_ -> Error str
 
 instance Functor BParser where


### PR DESCRIPTION
This makes the package compile with GHC-8.8 but probably needs more [work](https://gitlab.haskell.org/ghc/ghc/wikis/proposal/monad-fail#adapting-old-code).