### PR TITLE
Support the new MonadFail class introduced by ghc-8.8.1.

### DIFF
--- a/bencode.cabal
+++ b/bencode.cabal
@@ -51,6 +51,8 @@ test-suite doctests
   build-depends:  base == 4.*
                 , doctest >= 0.8
                 , bencode
+  if !impl(ghc >= 8.0)
+    build-depends: fail >= 4.9.0.0 && < 4.10
 
 test-suite spec
   ghc-options:    -Wall

--- a/src/Data/BEncode/Parser.hs
+++ b/src/Data/BEncode/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  BParser
@@ -27,6 +28,7 @@ module Data.BEncode.Parser {-#
 
 import           Control.Applicative        hiding (optional)
 import           Control.Monad
+import qualified Control.Monad.Fail         as Fail
 import           Data.BEncode
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map                   as Map
@@ -61,6 +63,9 @@ instance Monad BParser where
                                           Ok a b' -> runB (f a) b'
                                           Error str -> Error str
     return val = BParser $ Ok val
+#if MIN_VERSION_base(4,13,0)
+instance Fail.MonadFail BParser where
+#endif
     fail str = BParser $ \_ -> Error str
 
 instance Functor BParser where


### PR DESCRIPTION
See https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail for details.

Fixes https://github.com/creichert/bencode/issues/16.